### PR TITLE
Eliminate warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/*
 xcuserdata
 profile
 *.moved-aside
+
+.DS_Store
+/.DS_Store

--- a/NetworkUtility.h
+++ b/NetworkUtility.h
@@ -20,6 +20,8 @@
     - (ResponseData *)post:(NSString *)url withParameters:(NSDictionary *)params authenticate:(BOOL)authenticate error:(NSError *)error;
     - (ResponseData *)put:(NSString *)url withParameters:(NSDictionary *)params authenticate:(BOOL)authenticate error:(NSError *)error;
     - (ResponseData *)delete:(NSString *)url withParameters:(NSDictionary *)params authenticate:(BOOL)authenticate error:(NSError *)error;
+
+@optional
     - (ResponseData *)post:(NSString *)url withParameters:(NSDictionary *)params filePath:(NSString *)filePath authenticate:(BOOL)authenticate error:(NSError *)error;
     - (ResponseData *)postMultiPartFormData:(NSString *)url withParameters:(NSDictionary *)params authenticate:(BOOL)authenticate error:(NSError *)error;
 

--- a/RemoteNetworkUtility.h
+++ b/RemoteNetworkUtility.h
@@ -23,9 +23,6 @@ typedef enum {
 } RemoteNetworkUtilityAcceptsHeader;
 
 @interface RemoteNetworkUtility : NSObject <AbstractNetworkUtilityDelegate> 
-{
-    RemoteNetworkUtilityAcceptsHeader header;
-}
 
 @property (nonatomic, strong) NSURLConnection *connection;
 @property (nonatomic) RemoteNetworkUtilityAcceptsHeader header;

--- a/RemoteNetworkUtility.m
+++ b/RemoteNetworkUtility.m
@@ -20,9 +20,6 @@
 
 @implementation RemoteNetworkUtility
 
-@synthesize connection;
-@synthesize header;
-
 - (id)initWithAcceptsHeader:(RemoteNetworkUtilityAcceptsHeader)header {
     self.header = header;
     
@@ -202,7 +199,7 @@
     char encodeArray[512];
     memset(encodeArray, '\0', sizeof(encodeArray));
     base64encode([encodeData length], (char *)[encodeData bytes], sizeof(encodeArray), encodeArray);
-    dataStr = [NSString stringWithCString:encodeArray length:strlen(encodeArray)];
+    dataStr = [NSString stringWithCString:encodeArray encoding:NSUTF8StringEncoding];
     
     NSString *authenticationString = [@"" stringByAppendingFormat:@"Basic %@", dataStr];
     


### PR DESCRIPTION
Removed ivar declaration.
Removed @synthesize.
Refactored deprecated `- stringWithCString:length:` with `-stringWithCString:encoding:`.
